### PR TITLE
Fix delete retry

### DIFF
--- a/src/Pandora.Git/JarFinder.cs
+++ b/src/Pandora.Git/JarFinder.cs
@@ -87,7 +87,18 @@ namespace Pandora.Git
 
             File.SetAttributes(directoryPath, FileAttributes.Normal);
 
-            Directory.Delete(directoryPath, false);
+            try
+            {
+                Directory.Delete(directoryPath, true);
+            }
+            catch (IOException)
+            {
+                Directory.Delete(directoryPath, true);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Directory.Delete(directoryPath, true);
+            }
         }
 
         public void Dispose()

--- a/src/Pandora.Git/Pandora.Git.rn.md
+++ b/src/Pandora.Git/Pandora.Git.rn.md
@@ -1,3 +1,6 @@
+#### 0.1.9 - 12.12.2019
+* Fixes exception on deletion for directory
+
 #### 0.1.8 - 25.09.2018
 * Updates pandora package again
 


### PR DESCRIPTION
# Fix delete retry on exception

### Description
When we attempted to delete a directory, sometimes the file system would raise an unhandled UnauthorizedException. Due to this not being factually true, we simply retry to delete the directory.