### PR TITLE
Fix clean exception

### DIFF
--- a/src/Pandora.Git/JarFinder.cs
+++ b/src/Pandora.Git/JarFinder.cs
@@ -58,10 +58,18 @@ namespace Pandora.Git
 
         void Clean()
         {
-            var dirToDelete = new DirectoryInfo(_checkoutDir).Parent.Parent;
-            string workingDir = dirToDelete.Parent.FullName;
-            Directory.SetCurrentDirectory(workingDir);
-            DeleteDirectory(dirToDelete.FullName);
+            try
+            {
+                var dirToDelete = new DirectoryInfo(_checkoutDir).Parent.Parent;
+                string workingDir = dirToDelete.Parent.FullName;
+                Directory.SetCurrentDirectory(workingDir);
+
+                DeleteDirectory(dirToDelete.FullName);
+            }
+            catch (Exception)
+            {
+                // We will swallow any exceptions that arise, since this should not break startups that use these configurations. Currenlt, Windows.Filesystem throws on random occasions exceptions (UnauthorizedAccessException)}
+            }
         }
 
         void DeleteDirectory(string directoryPath)

--- a/src/Pandora.Git/Pandora.Git.rn.md
+++ b/src/Pandora.Git/Pandora.Git.rn.md
@@ -1,3 +1,6 @@
+#### 0.1.10 - 12.12.2019
+* Starts swallowing exceptions on Clean
+
 #### 0.1.9 - 12.12.2019
 * Fixes exception on deletion for directory
 


### PR DESCRIPTION
# Fix clean exception

### Description
We will swallow any exceptions that arise, since this should not break startups that use these configurations. Currenlt, Windows Filesystem throws on random occasions exceptions (UnauthorizedAccessException)}